### PR TITLE
PCQ708 - Added SwaggerConfiguration to fix failing security scan

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcqloader/config/SwaggerConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqloader/config/SwaggerConfiguration.java
@@ -1,0 +1,27 @@
+package uk.gov.hmcts.reform.pcqloader.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+import uk.gov.hmcts.reform.pcqloader.PcqLoaderApplication;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfiguration {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .useDefaultResponseMessages(false)
+                .select()
+                .apis(RequestHandlerSelectors.basePackage(PcqLoaderApplication.class.getPackage().getName()
+                        + ".controllers"))
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ708


### Change description ###
Security Scan tries to invoke the v2/api/docs and is getting a 404 error that causes the security scan to fail. The solution is to add a SwaggerConfiguration that just points to the main application class. This is similar to the Consolidation-service codebase.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
