### PR TITLE
PCQ708 - Removed security scan from nightly build

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -51,7 +51,7 @@ withNightlyPipeline(type, product, component) {
   disableLegacyDeployment()
   nonServiceApp()
 
-  enableSecurityScan()
+  //enableSecurityScan()
 
   enableMutationTest()
   after('mutationTest') {


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ708


### Change description ###
Security Scan removed from nightly build as pcq-loader does not expose any APIs.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
