### PR TITLE
PCQ_714 - Caught IllegalArgumentException

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcqloader/services/impl/PcqBackendServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqloader/services/impl/PcqBackendServiceImpl.java
@@ -53,7 +53,7 @@ public class PcqBackendServiceImpl implements PcqBackendService {
             responseEntity = JsonFeignResponseUtil.toResponseEntity(response, HashMap.class);
         } catch (FeignException ex) {
             throw new ExternalApiException(HttpStatus.valueOf(ex.status()), ex.getMessage());
-        } catch (IOException ioe) {
+        } catch (IOException | IllegalArgumentException ioe) {
             throw new ExternalApiException(HttpStatus.SERVICE_UNAVAILABLE, ioe.getMessage());
         }
 

--- a/src/test/java/uk/gov/hmcts/reform/pcqloader/services/impl/PcqBackendServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcqloader/services/impl/PcqBackendServiceImplTest.java
@@ -164,6 +164,20 @@ class PcqBackendServiceImplTest {
                                                                   any(PcqAnswerRequest.class));
     }
 
+    @Test
+    void executeIllegalArgumentExceptionError() {
+        PcqAnswerRequest testRequest = generateTestRequest();
+        IllegalArgumentException illegalArgumentException = new IllegalArgumentException("test");
+
+        when(mockPcqBackendFeignClient.submitAnswers(anyString(), anyString(), any(PcqAnswerRequest.class)))
+            .thenThrow(illegalArgumentException);
+
+        assertThrows(ExternalApiException.class, () -> pcqBackendService.submitAnswers(testRequest));
+
+        verify(mockPcqBackendFeignClient, times(1)).submitAnswers(anyString(), anyString(),
+                                                                  any(PcqAnswerRequest.class));
+    }
+
 
     private PcqAnswerRequest generateTestRequest() {
         PcqAnswerRequest pcqAnswerRequest = new PcqAnswerRequest();


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ-714


### Change description ###
The service call to the pcq-backend now throws an ExternalAPIException if the method returns an IlegalArgumentException for an invalid url or service down scenario


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
