### PR TITLE
PCQ_714 - Added check for http status in FeignException

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcqloader/services/impl/PcqBackendServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqloader/services/impl/PcqBackendServiceImpl.java
@@ -52,11 +52,20 @@ public class PcqBackendServiceImpl implements PcqBackendService {
                                                                      jwtToken, answerRequest)) {
             responseEntity = JsonFeignResponseUtil.toResponseEntity(response, HashMap.class);
         } catch (FeignException ex) {
-            throw new ExternalApiException(HttpStatus.valueOf(ex.status()), ex.getMessage());
+            HttpStatus httpStatus = checkAndReturnHttpStatus(ex.status());
+            throw new ExternalApiException(httpStatus, ex.getMessage());
         } catch (IOException | IllegalArgumentException ioe) {
             throw new ExternalApiException(HttpStatus.SERVICE_UNAVAILABLE, ioe.getMessage());
         }
 
         return responseEntity;
+    }
+
+    private HttpStatus checkAndReturnHttpStatus(int status) {
+        if (status == -1) {
+            return HttpStatus.SERVICE_UNAVAILABLE;
+        } else {
+            return HttpStatus.valueOf(status);
+        }
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/pcqloader/services/impl/PcqBackendServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/pcqloader/services/impl/PcqBackendServiceImplTest.java
@@ -165,6 +165,21 @@ class PcqBackendServiceImplTest {
     }
 
     @Test
+    void executeFeignApiUnknownError() {
+        PcqAnswerRequest testRequest = generateTestRequest();
+        FeignException feignException = new FeignException.FeignServerException(-1, "Bad error", mock(Request.class),
+                                                                                "TestError".getBytes());
+
+        when(mockPcqBackendFeignClient.submitAnswers(anyString(), anyString(), any(PcqAnswerRequest.class)))
+            .thenThrow(feignException);
+
+        assertThrows(ExternalApiException.class, () -> pcqBackendService.submitAnswers(testRequest));
+
+        verify(mockPcqBackendFeignClient, times(1)).submitAnswers(anyString(), anyString(),
+                                                                  any(PcqAnswerRequest.class));
+    }
+
+    @Test
     void executeIllegalArgumentExceptionError() {
         PcqAnswerRequest testRequest = generateTestRequest();
         IllegalArgumentException illegalArgumentException = new IllegalArgumentException("test");


### PR DESCRIPTION
### JIRA link (if applicable) ###
PCQ-714


### Change description ###
Added check for the FeignException catch block to check for status before throwing the ExternalAPIException.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
