### PR TITLE
Upgraded tomcat to 9.0.39

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ configurations.all {
                 details.useVersion '2.12.10'
             }
             if (details.requested.group in ['org.apache.tomcat.embed']) {
-                details.useVersion '9.0.37'
+                details.useVersion '9.0.39'
             }
         }
     }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,4 +14,18 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
+  <suppress until="2021-01-31">
+    <notes><![CDATA[
+   file name: tomcat-embed-core-9.0.39.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
+    <cve>CVE-2020-13943</cve>
+  </suppress>
+  <suppress until="2021-01-31">
+    <notes><![CDATA[
+   file name: tomcat-embed-websocket-9.0.39.jar
+   ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
+    <cve>CVE-2020-13943</cve>
+  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A


### Change description ###
The nightly build failed due to dependency check error on Tomcat version. The same has been fixed on pcq-backend repo too. This fix has upgraded tomcat to 9.0.39 and added temporary suppression (Please see https://github.com/jeremylong/DependencyCheck/issues/2926)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
