### PR TITLE
PCQ-742 Addressing CVE-2020-17527 in PCQ-Loader

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,7 +219,7 @@ configurations.all {
                 details.useVersion '2.12.10'
             }
             if (details.requested.group in ['org.apache.tomcat.embed']) {
-                details.useVersion '9.0.39'
+                details.useVersion '9.0.41'
             }
             if (details.requested.group in ['org.apache.httpcomponents.httpclient']) {
               details.useVersion '4.5.13'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -14,18 +14,4 @@
     <cve>CVE-2020-10663</cve>
     <cve>CVE-2020-7712</cve>
   </suppress>
-  <suppress until="2021-01-31">
-    <notes><![CDATA[
-   file name: tomcat-embed-core-9.0.39.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
-    <cve>CVE-2020-13943</cve>
-  </suppress>
-  <suppress until="2021-01-31">
-    <notes><![CDATA[
-   file name: tomcat-embed-websocket-9.0.39.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
-    <cve>CVE-2020-13943</cve>
-  </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-742


### Change description ###
Fix for vulnerability to tomcat-embed-xxx to 9.0.41 and remove existing suppressions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
