### PR TITLE
PCQ‐1134: Update pcq-loader to Gradle 7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,10 +78,11 @@ sourceSets {
 }
 
 configurations {
-    integrationTestCompile.extendsFrom testCompile
+    integrationTestImplementation.extendsFrom testImplementation
     integrationTestRuntime.extendsFrom testRuntime
-    functionalTestCompile.extendsFrom testCompile
+    functionalTestImplementation.extendsFrom testImplementation
     functionalTestRuntime.extendsFrom testRuntime
+    smokeTestRuntime.extendsFrom testRuntime
 }
 
 tasks.withType(JavaCompile) {
@@ -122,7 +123,7 @@ checkstyle {
   maxWarnings = 0
   toolVersion = '8.29'
   // need to set configDir to rootDir otherwise submodule will use submodule/config/checkstyle
-  configDir = new File(rootDir, 'config/checkstyle')
+  configDirectory = new File(rootDir, 'config/checkstyle')
 }
 
 pmd {
@@ -267,13 +268,13 @@ dependencies {
         exclude group: 'org.springframework.cloud', module: 'spring-cloud-context'
     }
 
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-web-services'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-json'
-    compile group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
-    compile group: 'org.springframework.boot', name: 'spring-boot-starter-security'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web-services'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-configuration-processor'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-security'
 
     implementation group: 'org.springframework', name:'spring-aop', version: versions.springFramework
     implementation group: 'org.springframework', name:'spring-beans', version: versions.springFramework
@@ -292,19 +293,19 @@ dependencies {
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-validation'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap'
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix', version: '2.2.7.RELEASE'
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign'
+    implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign'
 
-    compile group: 'org.projectlombok', name: 'lombok', version: versions.lombok
-    compile group: "com.networknt", name: "json-schema-validator", version: "1.0.31"
+    implementation group: 'org.projectlombok', name: 'lombok', version: versions.lombok
+    implementation group: "com.networknt", name: "json-schema-validator", version: "1.0.31"
 
-    compile group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
-    compile group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'
-    compile group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
+    implementation group: 'io.github.openfeign.form', name: 'feign-form', version: '3.8.0'
+    implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: '3.8.0'
+    implementation group: 'io.springfox', name: 'springfox-swagger2', version: versions.springfoxSwagger
 
-    compile group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.1.0', withoutSpringCloudContext
-    compile group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
-    compile group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
-    compile group: "com.gilecode.yagson", name:"j9-reflection-utils", version:"1.0"
+    implementation group: 'uk.gov.hmcts.reform', name: 'properties-volume-spring-boot-starter', version:'0.1.0', withoutSpringCloudContext
+    implementation group: 'uk.gov.hmcts.reform', name: 'logging', version: versions.reformLogging
+    implementation group: 'uk.gov.hmcts.reform', name: 'logging-appinsights', version: versions.reformLogging
+    implementation group: "com.gilecode.yagson", name:"j9-reflection-utils", version:"1.0"
 
     implementation group: "io.jsonwebtoken", name: "jjwt", version: "0.9.1"
     implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
@@ -314,43 +315,43 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
 
-    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-    testCompile group: 'org.springframework.security', name: 'spring-security-test'
+    testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
+    testImplementation group: 'org.springframework.security', name: 'spring-security-test'
 
-    testCompile group: 'org.pitest', name: 'pitest', version: versions.pitest
-    testCompile 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.7'
-    testCompile 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
+    testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
+    testImplementation 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.4.7'
+    testImplementation 'org.codehaus.sonar-plugins:sonar-pitest-plugin:0.5'
 
-    testCompile group: 'io.rest-assured', name: 'xml-path', version: versions.restAssured
-    testCompile group: 'io.rest-assured', name: 'json-path', version: versions.restAssured
+    testImplementation group: 'io.rest-assured', name: 'xml-path', version: versions.restAssured
+    testImplementation group: 'io.rest-assured', name: 'json-path', version: versions.restAssured
 
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.4.6'
-    testCompile group: 'org.mockito', name: 'mockito-inline', version: '3.4.6'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.4.6'
+    testImplementation group: 'org.mockito', name: 'mockito-inline', version: '3.4.6'
 
-    testCompile group: 'com.github.tomakehurst', name: 'wiremock', version: '2.19.0'
+    testImplementation group: 'com.github.tomakehurst', name: 'wiremock', version: '2.19.0'
 
-    testCompile 'com.github.hmcts:fortify-client:1.2.0:all'
+    testImplementation 'com.github.hmcts:fortify-client:1.2.0:all'
 
     testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-webflux'
     testImplementation group: "com.gilecode.yagson", name:"j9-reflection-utils", version:"1.0"
     testImplementation group: "io.jsonwebtoken", name: "jjwt", version: "0.9.1"
     testImplementation group: "org.testcontainers", name: "junit-jupiter", version: versions.testcontainers
 
-    integrationTestCompile sourceSets.main.runtimeClasspath
-    integrationTestCompile sourceSets.test.runtimeClasspath
+    integrationTestImplementation sourceSets.main.runtimeClasspath
+    integrationTestImplementation sourceSets.test.runtimeClasspath
 
-    functionalTestCompile sourceSets.main.runtimeClasspath
-    functionalTestCompile sourceSets.test.runtimeClasspath
+    functionalTestImplementation sourceSets.main.runtimeClasspath
+    functionalTestImplementation sourceSets.test.runtimeClasspath
     functionalTestCompileOnly group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     functionalTestAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
 
-    smokeTestCompile group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
+    smokeTestImplementation group: 'io.rest-assured', name: 'rest-assured', version: versions.restAssured
     smokeTestRuntime group: 'io.rest-assured', name: 'xml-path', version: versions.restAssured
     smokeTestRuntime group: 'io.rest-assured', name: 'json-path', version: versions.restAssured
     smokeTestRuntime group: 'io.rest-assured', name: 'kotlin-extensions', version: versions.restAssured
 
-    smokeTestCompile sourceSets.main.runtimeClasspath
-    smokeTestCompile sourceSets.test.runtimeClasspath
+    smokeTestImplementation sourceSets.main.runtimeClasspath
+    smokeTestImplementation sourceSets.test.runtimeClasspath
 }
 
 test {
@@ -366,4 +367,20 @@ bootJar {
     manifest {
         attributes('Implementation-Version': project.version.toString())
     }
+}
+
+rootProject.tasks.named("processTestResources") {
+  duplicatesStrategy = 'include'
+}
+
+rootProject.tasks.named("processFunctionalTestResources") {
+  duplicatesStrategy = 'include'
+}
+
+rootProject.tasks.named("processIntegrationTestResources") {
+  duplicatesStrategy = 'include'
+}
+
+rootProject.tasks.named("processSmokeTestResources") {
+  duplicatesStrategy = 'include'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/PCQ-1134

### Change description ###
Update pcq-loader to Gradle 7.2

Summary of issues fixed :-

**Error:**	Could not set unknown property 'configDir' for extension 'checkstyle' of type org.gradle.api.plugins.quality.CheckstyleExtension.
**Fix:**	Replace 'configDir' with 'configDirectory'

**Error:** 	Could not find method compile() ...
**Fix:**	Replace 'compile' with 'implementation'		(in dependencies block)
	Replace 'estCompile' with 'estImplementation'	(throughout build.gradle)

**Error:**	Entry xxxxxxxx is a duplicate but no duplicate handling strategy has been set.
**Fix:**	Add rootProject.tasks.named .... duplicatesStrategy = 'include'

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```