### PR TITLE
PCQ-1541: Update to delay deletion of containers

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/pcqloader/postdeploy/PcqLoaderFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/pcqloader/postdeploy/PcqLoaderFunctionalTest.java
@@ -79,7 +79,7 @@ public class PcqLoaderFunctionalTest extends PcqLoaderTestBase {
     @After
     public void afterTests() throws InterruptedException {
         log.info("Stopping PcqLoaderComponent functional tests");
-        log.info("Waiting for 10 Sec before deleting to allow tests to finish");
+        log.info("Waiting {}ms before deleting containers to allow all tests to finish", waitPeriod);
         waitToDeleteContainer();
         blobStorageManager.deleteContainer(FUNC_TEST_PCQ_CONTAINER_NAME);
         blobStorageManager.deleteContainer(FUNC_TEST_PCQ_REJECTED_CONTAINER_NAME);

--- a/src/functionalTest/resources/application-functional.yaml
+++ b/src/functionalTest/resources/application-functional.yaml
@@ -24,10 +24,13 @@ api-schema-file:
   submitanswer-schema: JsonSchema/submitAnswersSchema.json
 api-version-number: 1
 
-#Application specific unit test properties
+#Application specific test properties
 unit-test:
   api-urls:
     submit_answer: /pcq/backend/submitAnswers
+functional-test:
+  wait:
+    period: 120000
 
 spring:
   application:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-1541


### Change description ###
Update to delay deletion of containers as parallel tests are being run. If the tests start at the same time, the containers being deleted do not present an issue, if they are out of sync, then the second set of tests can sometimes attempt to create a container while it's being actively deleted. This is a temporary fix until a better solution can be found.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```