### PR TITLE
PCQ-1623 removing suppression CVE-2021-67533

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -352,6 +352,7 @@ dependencies {
     implementation group: 'org.yaml', name: 'snakeyaml', version: '1.33'
     implementation group: 'com.fasterxml.woodstox', name: 'woodstox-core', version: '6.5.0'
     implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
+    implementation group: 'commons-net', name: 'commons-net', version: '3.9.0'
 
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -11,7 +11,6 @@
     <cve>CVE-2022-22968</cve>
     <cve>CVE-2022-22976</cve>
     <cve>CVE-2022-22978</cve>
-    <cve>CVE-2021-37533</cve>
   </suppress>
   <suppress>
     <packageUrl regex="true">^pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@.*$</packageUrl>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-1623


### Change description ###
This change is to suppress CVE-2021-37533


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```