### PR TITLE
PCQ-2244 Adding MDC key for all the logs to use for alert

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/pcqloader/PcqLoaderApplication.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqloader/PcqLoaderApplication.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.pcqloader;
 import com.microsoft.applicationinsights.TelemetryClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
@@ -11,6 +12,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.ApplicationContext;
+
+import static uk.gov.hmcts.reform.pcqloader.utils.PcqLoaderConstants.PCQ_LOADER_ERROR_MARKER;
 
 
 @SpringBootApplication(scanBasePackages = "uk.gov.hmcts.reform")
@@ -35,13 +38,10 @@ public class PcqLoaderApplication implements ApplicationRunner {
             pcqLoaderComponent.execute();
             log.info("Completed the Pcq Loader job successfully.");
         } catch (Exception e) {
-            //This specific message error has been added in Azure log to look for these traces in alert
-            // query and create alert if disposer-idam-user throw any exception because of any reason.
-            log.error("Error executing Pcq Loader : " +  e);
-            //To have stack trace of this exception as we are catching the exception
-            // stack trace will not be logged by azure
+            MDC.put("errorType", PCQ_LOADER_ERROR_MARKER);
             log.error("Error executing Pcq Loader", e);
         } finally {
+            MDC.clear();
             client.flush();
             waitTelemetryGracefulPeriod();
         }

--- a/src/main/java/uk/gov/hmcts/reform/pcqloader/PcqLoaderComponent.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqloader/PcqLoaderComponent.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.pcqloader;
 import com.azure.storage.blob.BlobContainerClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static uk.gov.hmcts.reform.pcqloader.utils.PcqLoaderConstants.PCQ_LOADER_ERROR_MARKER;
 
 @Component
 @Slf4j
@@ -75,6 +78,7 @@ public class PcqLoaderComponent {
                 // Step 7. Read the file and generate the mapping to the PcqAnswers object.
                 File metaDataFile = fileUtil.getMetaDataFile(Objects.requireNonNull(unzippedFiles.listFiles()));
                 if (metaDataFile == null) {
+                    MDC.put("errorType", PCQ_LOADER_ERROR_MARKER);
                     log.error("metadata.json file not found, moving the zip file to Rejected container");
                     blobStorageManager.moveFileToRejectedContainer(tmpZipFileName, blobContainerClient);
                     incrementServiceCount(jurisdiction + ERROR_SUFFIX);
@@ -95,7 +99,8 @@ public class PcqLoaderComponent {
                     }
                 }
             } catch (Exception ioe) {
-                log.error("Error during processing " + ioe.getMessage(), ioe);
+                MDC.put("errorType", PCQ_LOADER_ERROR_MARKER);
+                log.error("Error during processing {} ", ioe.getMessage(), ioe);
                 incrementServiceCount(jurisdiction + ERROR_SUFFIX);
             } finally {
                 fileUtil.deleteFilesFromLocalStorage(blobZipDirectory, unzippedFiles);

--- a/src/main/java/uk/gov/hmcts/reform/pcqloader/helper/PayloadMappingHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqloader/helper/PayloadMappingHelper.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.pcq.commons.model.PcqAnswerRequest;
@@ -18,6 +19,7 @@ import uk.gov.hmcts.reform.pcq.commons.utils.PcqUtils;
 import java.util.Base64;
 
 import static uk.gov.hmcts.reform.pcq.commons.utils.PcqUtils.nullIfEmpty;
+import static uk.gov.hmcts.reform.pcqloader.utils.PcqLoaderConstants.PCQ_LOADER_ERROR_MARKER;
 
 @Component
 @Slf4j
@@ -61,9 +63,13 @@ public class PayloadMappingHelper extends PayloadMappingHelperBase {
             }
 
         } catch (JsonProcessingException jpe) {
-            log.error("JsonProcessingException during payload parsing - " + jpe.getMessage());
+            MDC.put("errorType", PCQ_LOADER_ERROR_MARKER);
+            log.error("JsonProcessingException during payload parsing - {}  ", jpe.getMessage());
+
         } catch (NumberFormatException nfe) {
-            log.error("NumberFormatException during payload parsing - " + nfe.getMessage());
+            MDC.put("errorType", PCQ_LOADER_ERROR_MARKER);
+            log.error("NumberFormatException during payload parsing - {} ", nfe.getMessage());
+
         }
 
         return null;

--- a/src/main/java/uk/gov/hmcts/reform/pcqloader/utils/PcqLoaderConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqloader/utils/PcqLoaderConstants.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.pcqloader.utils;
 
 public final class PcqLoaderConstants {
-    public static final String PCQ_LOADER_ERROR_MARKER = "PcqLoaderError: ";
+    public static final String PCQ_LOADER_ERROR_MARKER = "PCQ_LOADER_ERROR";
 
     private PcqLoaderConstants() {
          // Private constructor to prevent instantiation

--- a/src/main/java/uk/gov/hmcts/reform/pcqloader/utils/PcqLoaderConstants.java
+++ b/src/main/java/uk/gov/hmcts/reform/pcqloader/utils/PcqLoaderConstants.java
@@ -1,0 +1,9 @@
+package uk.gov.hmcts.reform.pcqloader.utils;
+
+public final class PcqLoaderConstants {
+    public static final String PCQ_LOADER_ERROR_MARKER = "PcqLoaderError: ";
+
+    private PcqLoaderConstants() {
+         // Private constructor to prevent instantiation
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PCQ-2244


### Change description ###
Adding MDC (Mapped Diagnostic Context) to use in alert query rather than message so that I can use like
traces
| where customDimensions  == "PCQLoaderError"


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```